### PR TITLE
Improve Twig templates compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 6.0.3 - 2021-02-18
+### Changed
+- Improve Twig templates compatibility
+
 ## 6.0.2 - 2020-05-15
 ### Changed
 - Switched from PSR-0 to PSR-4 autoloading

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": "^7.0",
         "symfony/symfony": "^3.4",
+        "twig/twig": "^1.40 || ^2.9",
         "jms/metadata": "^1.5",
         "zicht/util": "^1.7",
         "doctrine/orm": "^2.5"

--- a/src/Zicht/Bundle/FileManagerBundle/DependencyInjection/ZichtFileManagerExtension.php
+++ b/src/Zicht/Bundle/FileManagerBundle/DependencyInjection/ZichtFileManagerExtension.php
@@ -28,8 +28,13 @@ class ZichtFileManagerExtension extends DIExtension
         $loader = new XmlFileLoader($container, new FileLocator(array(__DIR__.'/../Resources/config/')));
         $loader->load('services.xml');
 
+        $bundles = $container->getParameter('kernel.bundles');
         $formResources = $container->getParameter('twig.form.resources');
-        $formResources[] = 'ZichtFileManagerBundle::form_theme.html.twig';
+        if (array_key_exists('ZichtMoxieManagerBundle', $bundles) && array_key_exists('LiipImagineBundle', $bundles)) {
+            $formResources[] = 'ZichtFileManagerBundle::form_theme.html.twig';
+        } else {
+            $formResources[] = 'ZichtFileManagerBundle::form_theme_simple.html.twig';
+        }
         $container->setParameter('twig.form.resources', $formResources);
 
         $container->setParameter('zicht_filemanager.naming_strategy.case_preservation', $config['case_preservation']);

--- a/src/Zicht/Bundle/FileManagerBundle/Resources/public/js/edit-image.js
+++ b/src/Zicht/Bundle/FileManagerBundle/Resources/public/js/edit-image.js
@@ -10,7 +10,8 @@ $(function () {
         if (fileUrl) {
             fileUrl = fileUrl.split('?')[0];
 
-            $trigger.click(function (e) {
+            $trigger.show()
+                .click(function (e) {
                 e.preventDefault();
 
                 moxman.edit({

--- a/src/Zicht/Bundle/FileManagerBundle/Resources/translations/admin.en.yml
+++ b/src/Zicht/Bundle/FileManagerBundle/Resources/translations/admin.en.yml
@@ -3,7 +3,6 @@ zicht_filemanager:
     remove_file_note: Uploading a new file will replice an existing one
     upload_file: Upload file
     wrong_type: 'The file type (%this_type%) is not allowed.  Allowed types are: %allowed_types%'
-    select_table_header: ''
     value_table_header: Select source
     url_label: URL
     upload_label: Upload

--- a/src/Zicht/Bundle/FileManagerBundle/Resources/translations/admin.nl.yml
+++ b/src/Zicht/Bundle/FileManagerBundle/Resources/translations/admin.nl.yml
@@ -3,7 +3,6 @@ zicht_filemanager:
     remove_file_note:   "Door een nieuw bestand te selecteren wordt de bestaande vervangen"
     upload_file:        "Bestand uploaden"
     wrong_type:         "Het bestand type (%this_type%) is niet toegestaan, toegestaande types: %allowed_types%"
-    select_table_header: ""
     value_table_header: "Selecteer bron"
     url_label: "URL"
     upload_label: "Upload"

--- a/src/Zicht/Bundle/FileManagerBundle/Resources/views/Sonata/list/image.html.twig
+++ b/src/Zicht/Bundle/FileManagerBundle/Resources/views/Sonata/list/image.html.twig
@@ -1,8 +1,10 @@
 {% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
+
 {% block field %}
+    {% set image_url = file_url(object, field_description.getFieldName()) %}
     {% if field_description.options.imagine_filter is defined %}
-        <img src="{{ file_url(object, field_description.getFieldName())|imagine_filter(field_description.options.imagine_filter) }}">
+        <img src="{{ image_url|imagine_filter(field_description.options.imagine_filter) }}" title="{{ image_url }}" alt="">
     {% else %}
-        <img src="{{ asset(file_url(object, field_description.getFieldName())) }}">
+        <img src="{{ asset(image_url) }}" title="{{ image_url }}" alt="" style="max-height: 50px; max-width: 50px;">
     {% endif %}
 {% endblock %}

--- a/src/Zicht/Bundle/FileManagerBundle/Resources/views/Sonata/list/image_simple.html.twig
+++ b/src/Zicht/Bundle/FileManagerBundle/Resources/views/Sonata/list/image_simple.html.twig
@@ -1,0 +1,6 @@
+{% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
+
+{% block field %}
+    {% set image_url = file_url(object, field_description.getFieldName()) %}
+    <img src="{{ asset(image_url) }}" title="{{ image_url }}" alt="" style="max-height: 50px; max-width: 50px;">
+{% endblock %}

--- a/src/Zicht/Bundle/FileManagerBundle/Resources/views/form_theme.html.twig
+++ b/src/Zicht/Bundle/FileManagerBundle/Resources/views/form_theme.html.twig
@@ -1,93 +1,98 @@
 {% block zicht_file_widget %}
-    {% if file_url is defined and show_current_file %}
-        <div class="js-moxiemanager-edit-image">
-            <p>
-                <a href="{{ asset(file_url) }}">
-                    {% if (file_url|lower[-3:] in ['jpg', 'jpeg', 'png', 'gif'] or file_url|lower[-5:] == '.jpeg') %}
-                        <div class="js-moxiemanager-edit-image__image-preview">
-                            <img title="(Current: {{ file_url }})" alt="" src="{{ file_url|imagine_filter('cms') }}">
-                        </div>
-                    {% elseif (file_url|lower[-3:] in ['mp3']) %}
-                        <audio src="{{ asset(file_url) }}" controls></audio>
-                    {% else %}
-                        {{ file_url }}
+    <div style="margin-left: 2em;">
+        {% block zicht_file_widget__current_file %}
+            {% if file_url is defined and show_current_file %}
+                <div class="js-moxiemanager-edit-image">
+                    <p>
+                        <a href="{{ asset(file_url) }}" target="_blank">
+                            {% if (file_url|lower[-3:] in ['jpg', 'jpeg', 'png', 'gif'] or file_url|lower[-5:] == '.jpeg') %}
+                                <div class="js-moxiemanager-edit-image__image-preview">
+                                    <img title="(Current: {{ file_url }})" alt="" src="{{ file_url|imagine_filter('cms') }}">
+                                </div>
+                            {% elseif (file_url|lower[-3:] in ['mp3']) %}
+                                <audio src="{{ asset(file_url) }}" controls></audio>
+                            {% else %}
+                                {{ file_url }}
+                            {% endif %}
+                        </a>
+
+                        {% if file_url|lower[-3:] in ['jpg', 'jpeg', 'png', 'gif'] or file_url|lower[-5:] == '.jpeg' %}
+                            <a href="javascript:void(0);" class="js-moxiemanager-edit-image__trigger" style="display: none;" data-file-url="{{ asset(file_url) }}"><i class="ion-edit"></i></a>
+                        {% endif %}
+                    </p>
+                </div>
+            {% endif %}
+        {% endblock %}
+
+        {% block zicht_file_widget__actions %}
+            {%- apply spaceless %}
+                <div {{ block('widget_container_attributes') }}>
+                    {% if form.parent is empty %}
+                        {{ form_errors(form) }}
                     {% endif %}
-                </a>
+                    {% if allow_url == true %}
+                        <table class="zicht_file">
+                            <thead>
+                            <tr>
+                                <th colspan="2">{{ 'zicht_filemanager.value_table_header'|trans({}, translation_domain) }}</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td style="padding-right: 1.4em;">
+                                    <input type="radio" name="{{ form.select.vars.full_name }}" value="{{ constant('Zicht\\Bundle\\FileManagerBundle\\Form\\FileType::FILE_UPLOAD') }}"{{ form.select.vars.value == constant('Zicht\\Bundle\\FileManagerBundle\\Form\\FileType::FILE_UPLOAD') ? ' checked="checked"' : '' }}> </td>
+                                </td>
+                                <td>
+                                    {{ form_label(form.upload_file) }}
+                                    {{ form_widget(form.upload_file) }}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="padding-right: 1.4em;">
+                                    <input type="radio" name="{{ form.select.vars.full_name }}" value="{{ constant('Zicht\\Bundle\\FileManagerBundle\\Form\\FileType::FILE_URL') }}"{{ form.select.vars.value == constant('Zicht\\Bundle\\FileManagerBundle\\Form\\FileType::FILE_URL') ? ' checked="checked"' : '' }}>
+                                </td>
+                                <td>
+                                    {{ form_label(form.url) }}
+                                    {{ form_widget(form.url) }}
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    {% else %}
+                        <input type="hidden" name="{{ form.select.vars.full_name }}" value="{{ constant('Zicht\\Bundle\\FileManagerBundle\\Form\\FileType::FILE_UPLOAD') }}">
+                        {% do form.url.setRendered %} {# don't need to render the url field #}
+                        {% do form.select.setRendered %} {# don't need to render the radio button #}
+                        {{ form_row(form.upload_file) }}
+                    {% endif %}
 
-                {% if file_url|lower[-3:] in ['jpg', 'jpeg', 'png', 'gif'] or file_url|lower[-5:] == '.jpeg' %}
-                    <a href="#" class="js-moxiemanager-edit-image__trigger" data-file-url="{{ asset(file_url) }}"><i class="ion-edit"></i></a>
-                {% endif %}
-            </p>
-        </div>
-    {% endif %}
+                    {{ form_widget(form.hash) }} {# hidden field #}
+                    {{ form_widget(form.filename) }} {# hidden field #}
 
-    {% spaceless %}
-        <div {{ block('widget_container_attributes') }}>
-            {% if form.parent is empty %}
-                {{ form_errors(form) }}
-            {% endif %}
-            {% if allow_url == true %}
-                <table class="zicht_file">
-                    <thead>
-                    <tr>
-                        <th>{{ 'zicht_filemanager.select_table_header'|trans({}, translation_domain) }}</th>
-                        <th>{{ 'zicht_filemanager.value_table_header'|trans({}, translation_domain) }}</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr>
-                        <td>
-                            <input type="radio" name="{{ form.select.vars.full_name }}" value="{{ constant('Zicht\\Bundle\\FileManagerBundle\\Form\\FileType::FILE_UPLOAD') }}"{{ form.select.vars.value == constant('Zicht\\Bundle\\FileManagerBundle\\Form\\FileType::FILE_UPLOAD') ? ' checked="checked"' : '' }}> </td>
-                        </td>
-                        <td>
-                            {{ form_label(form.upload_file) }}
-                            {{ form_widget(form.upload_file) }}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <input type="radio" name="{{ form.select.vars.full_name }}" value="{{ constant('Zicht\\Bundle\\FileManagerBundle\\Form\\FileType::FILE_URL') }}"{{ form.select.vars.value == constant('Zicht\\Bundle\\FileManagerBundle\\Form\\FileType::FILE_URL') ? ' checked="checked"' : '' }}>
-                        </td>
-                        <td>
-                            {{ form_label(form.url) }}
-                            {{ form_widget(form.url) }}
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-            {% else %}
-                <input type="hidden" name="{{ form.select.vars.full_name }}" value="{{ constant('Zicht\\Bundle\\FileManagerBundle\\Form\\FileType::FILE_UPLOAD') }}">
-                {% do form.url.setRendered %} {# don't need to render the url field #}
-                {% do form.select.setRendered %} {# don't need to render the radio button #}
-                {{ form_row(form.upload_file) }}
-            {% endif %}
+                    {% if form.remove is defined %}
+                        {% if file_url is defined %}
+                            <p><small>{{ "zicht_filemanager.remove_file_note"|trans({}, translation_domain) }}</small></p>
+                            {{ form_widget(form.remove) }}
+                        {% endif %}
+                        {% if form.remove|default %}
+                            {% do form.remove.setRendered %}
+                        {% endif %}
+                        {% if form.select|default %}
+                            {% do form.select.setRendered %} {# not sure there is a better way to do this #}
+                        {% endif %}
+                    {% endif %}
 
-            {{ form_widget(form.hash) }} {# hidden field #}
-            {{ form_widget(form.filename) }} {# hidden field #}
+                    {% if form.keep_previous_filename is defined %}
+                        {% if file_url is defined %}
+                            <p><small>{{ "zicht_filemanager.keep_previous_filename_note"|trans({}, translation_domain) }}</small></p>
+                            {{ form_widget(form.keep_previous_filename) }}
+                        {% else %}
+                            {% do form.keep_previous_filename.setRendered %}
+                        {% endif %}
+                    {% endif %}
 
-            {% if form.remove is defined %}
-                {% if file_url is defined %}
-                    <p><small>{{ "zicht_filemanager.remove_file_note"|trans({}, translation_domain) }}</small></p>
-                    {{ form_widget(form.remove) }}<span style="margin-left:7px;">{{ form_label(form.remove) }}</span>
-                {% endif %}
-                {% if form.remove|default %}
-                    {% do form.remove.setRendered %}
-                {% endif %}
-                {% if form.select|default %}
-                    {% do form.select.setRendered %} {# not sure there is a better way to do this #}
-                {% endif %}
-            {% endif %}
-
-            {% if form.keep_previous_filename is defined %}
-                {% if file_url is defined %}
-                    <p><small>{{ "zicht_filemanager.keep_previous_filename_note"|trans({}, translation_domain) }}</small></p>
-                    {{ form_widget(form.keep_previous_filename) }}<span style="margin-left:7px;">{{ form_label(form.keep_previous_filename) }}</span>
-                {% else %}
-                    {% do form.keep_previous_filename.setRendered %}
-                {% endif %}
-            {% endif %}
-
-            {{ form_rest(form) }}
-        </div>
-    {% endspaceless %}
+                    {{ form_rest(form) }}
+                </div>
+            {% endapply -%}
+        {% endblock %}
+    </div>
 {% endblock %}

--- a/src/Zicht/Bundle/FileManagerBundle/Resources/views/form_theme_simple.html.twig
+++ b/src/Zicht/Bundle/FileManagerBundle/Resources/views/form_theme_simple.html.twig
@@ -1,0 +1,19 @@
+{% extends 'ZichtFileManagerBundle::form_theme.html.twig' %}
+
+{% block zicht_file_widget__current_file %}
+    {% if file_url is defined and show_current_file %}
+        <p>
+            <a href="{{ asset(file_url) }}" target="_blank">
+                {% if (file_url|lower[-3:] in ['jpg', 'jpeg', 'png', 'gif'] or file_url|lower[-5:] == '.jpeg') %}
+                    <img title="(Current: {{ file_url }})" alt="" src="{{ asset(file_url) }}" style="max-height: 50px; max-width: 50px;">
+                {% elseif (file_url|lower[-3:] in ['mp3']) %}
+                    <audio src="{{ asset(file_url) }}" controls></audio>
+                {% else %}
+                    <p>
+                        {{ file_url }}
+                    </p>
+                {% endif %}
+            </a>
+        </p>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
- General improvements in the Twig templates used in the admin
- Fixed the compatibility when not using MoxieManager and Liip Imagine bundles
- Fixed deprecated Twig functionalities

Als je geen Liip Imagine bundle hebt geïnstalleerd, dan krijg je errors op het gebruik van de `|imagine_filter(...)` filter. Ook als deze binnen een if-statement waar hij niet bereikt wordt. Twig zoekt de bijbehorende filter definities al op tijdens het parsen blijkbaar.

![Screenshot from 2021-02-18 14-08-40](https://user-images.githubusercontent.com/2794908/108361495-dbe25680-71f2-11eb-8968-ff482ba77195.png)


Ook de styling wat aangepakt:

| voor | na |
|---|---|
| ![voor](https://user-images.githubusercontent.com/2794908/108356056-e77e4f00-71eb-11eb-8a1e-5516d9b7c11e.png) | ![na](https://user-images.githubusercontent.com/2794908/108356045-e2210480-71eb-11eb-806c-3649ede6e344.png) |